### PR TITLE
Fix bonding and movement rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,9 @@ const inputA = ['H','O','C','H','H'];
 const inputB = ['C','H','O','O'];
 let inputIndexA=0, inputIndexB=0;
 const outputsA=[], outputsB=[];
+// fixed spawn locations for inputs (independent of waldo position)
+const inputPosA = {x:0,y:0};
+const inputPosB = {x:0,y:4};
 
 let eraseMode = false;
 
@@ -129,6 +132,14 @@ let startRed = null, startBlue = null;
 
 function atomAt(x,y) {
     return atoms.find(a => !a.held && a.x===x && a.y===y);
+}
+
+function atomAtIncludingHeld(x,y){
+    const a = atomAt(x,y);
+    if(a) return a;
+    if(red.holding && red.x===x && red.y===y) return red.holding;
+    if(blue.holding && blue.x===x && blue.y===y) return blue.holding;
+    return null;
 }
 
 function drawGrid() {
@@ -313,13 +324,20 @@ function step(){
     draw();
 }
 
+function crash(waldo){
+    running=false;
+    clearInterval(timer);
+    alert(waldo.color + ' waldo crashed into wall');
+}
+
 function execute(waldo){
     if(!waldo.started) return;
     // sync waiting?
     if(waldo.waiting){
         const other = waldo===red?blue:red;
-        if(!other.waiting) return;
+        if(!other.waiting) return; // stay here until other arrives
         waldo.waiting=false; other.waiting=false;
+        return; // resume next cycle from same tile
     }
 
     const instrLayer = waldo.color==='red'?instructionsRed:instructionsBlue;
@@ -328,14 +346,27 @@ function execute(waldo){
     const arrow = arrowLayer[waldo.y][waldo.x];
 
     handleInstruction(waldo,instr);
+    if(waldo.waiting) return; // sync causes wait on current tile
     if(arrow) waldo.dir=arrow;
 
-    // move forward
+    // move forward with wall collision
     const dir=waldo.dir;
-    if(dir==='right') waldo.x=(waldo.x+1)%gridW;
-    if(dir==='left') waldo.x=(waldo.x+gridW-1)%gridW;
-    if(dir==='up') waldo.y=(waldo.y+gridH-1)%gridH;
-    if(dir==='down') waldo.y=(waldo.y+1)%gridH;
+    if(dir==='right') {
+        if(waldo.x+1>=gridW) return crash(waldo);
+        waldo.x++;
+    }
+    if(dir==='left') {
+        if(waldo.x-1<0) return crash(waldo);
+        waldo.x--;
+    }
+    if(dir==='up') {
+        if(waldo.y-1<0) return crash(waldo);
+        waldo.y--;
+    }
+    if(dir==='down') {
+        if(waldo.y+1>=gridH) return crash(waldo);
+        waldo.y++;
+    }
 }
 
 function handleInstruction(waldo,instr){
@@ -362,29 +393,30 @@ function handleInstruction(waldo,instr){
                 if(a){ waldo.holding=a; a.held=true; a.holder=waldo; }
             }
             break;
-        case 'bond+': doBond(waldo,true); break;
-        case 'bond-': doBond(waldo,false); break;
+        case 'bond+': doBond(true); break;
+        case 'bond-': doBond(false); break;
         case 'sync': waldo.waiting=true; break;
-        case 'inA': spawnInput('A',waldo); break;
-        case 'inB': spawnInput('B',waldo); break;
+        case 'inA': spawnInput('A'); break;
+        case 'inB': spawnInput('B'); break;
         case 'outA': outputAtom('A',waldo); break;
         case 'outB': outputAtom('B',waldo); break;
         case 'swap': doSwap(); break;
-        case 'fuse': fuseAtoms(waldo); break;
-        case 'split': splitAtom(waldo); break;
+        case 'fuse': fuseAtoms(); break;
+        case 'split': splitAtom(); break;
         case 'rotate_cw': rotateHeld(waldo,true); break;
         case 'rotate_ccw': rotateHeld(waldo,false); break;
         // sense, sensors: left as extension; stub
     }
 }
 
-function spawnInput(ch, waldo){
+function spawnInput(ch){
     const list = ch==='A'?inputA:inputB;
     const idx = ch==='A'?inputIndexA:inputIndexB;
     if(idx>=list.length) return;
     const type=list[idx];
     if(ch==='A') inputIndexA++; else inputIndexB++;
-    const a={id:atomIdSeq++,type,x:waldo.x,y:waldo.y,held:false,bonds:[]};
+    const pos = ch==='A'?inputPosA:inputPosB;
+    const a={id:atomIdSeq++,type,x:pos.x,y:pos.y,held:false,bonds:[]};
     atoms.push(a);
 }
 
@@ -396,22 +428,28 @@ function outputAtom(ch, waldo){
     waldo.holding=null;
 }
 
-function doBond(waldo,make){
-    const a = atomAt(waldo.x,waldo.y) || waldo.holding;
-    if(!a) return;
-    const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
-    for(const [dx,dy] of dirs){
-        const nx=waldo.x+dx, ny=waldo.y+dy;
-        if(nx<0||nx>=gridW||ny<0||ny>=gridH) continue;
-        if(machines[ny][nx] && machines[ny][nx].startsWith('bonder')){
-            const b = atomAt(nx,ny) || (waldo.holding && waldo.holding.x===nx&&waldo.holding.y===ny?waldo.holding:null);
-            if(!b || b===a) continue;
-            if(make){
-                if(!a.bonds.includes(b)) a.bonds.push(b);
-                if(!b.bonds.includes(a)) b.bonds.push(a);
-            }else{
-                a.bonds=a.bonds.filter(x=>x!==b);
-                b.bonds=b.bonds.filter(x=>x!==a);
+function doBond(make){
+    for(let y=0;y<gridH;y++){
+        for(let x=0;x<gridW;x++){
+            const m=machines[y][x];
+            const valid=(m==='bonder'||(m==='bonder+'&&make)||(m==='bonder-'&&!make));
+            if(!valid) continue;
+            for(const [dx,dy] of [[1,0],[0,1]]){ // check right and down to avoid duplicates
+                const nx=x+dx, ny=y+dy;
+                if(nx>=gridW||ny>=gridH) continue;
+                const m2=machines[ny][nx];
+                const valid2=(m2==='bonder'||(m2==='bonder+'&&make)||(m2==='bonder-'&&!make));
+                if(!valid2) continue;
+                const a=atomAtIncludingHeld(x,y);
+                const b=atomAtIncludingHeld(nx,ny);
+                if(!a||!b||a===b) continue;
+                if(make){
+                    if(!a.bonds.includes(b)) a.bonds.push(b);
+                    if(!b.bonds.includes(a)) b.bonds.push(a);
+                }else{
+                    a.bonds=a.bonds.filter(p=>p!==b);
+                    b.bonds=b.bonds.filter(p=>p!==a);
+                }
             }
         }
     }
@@ -434,25 +472,31 @@ function doSwap(){
 }
 
 // simple placeholders for fuse/split/rotate to keep demo functional
-function fuseAtoms(waldo){
-    const a = atomAt(waldo.x,waldo.y);
-    const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
-    for(const [dx,dy] of dirs){
-        const b=atomAt(waldo.x+dx, waldo.y+dy);
-        if(a && b){
-            b.type=a.type+b.type;
-            atoms=atoms.filter(x=>x!==a);
-            break;
+function fuseAtoms(){
+    for(let y=0;y<gridH;y++){
+        for(let x=0;x<gridW;x++){
+            if(machines[y][x] !== 'fuser') continue;
+            const a = atomAtIncludingHeld(x,y);
+            const b = atomAtIncludingHeld(x+1,y);
+            if(a && b){
+                b.type = a.type + b.type;
+                atoms = atoms.filter(t=>t!==a);
+            }
         }
     }
 }
-function splitAtom(waldo){
-    const a = atomAt(waldo.x,waldo.y);
-    if(!a || a.type.length<2) return;
-    const t1=a.type[0], t2=a.type.slice(1);
-    a.type=t1;
-    const newAtom={id:atomIdSeq++,type:t2,x:waldo.x,y:waldo.y,held:false,bonds:[]};
-    atoms.push(newAtom);
+function splitAtom(){
+    for(let y=0;y<gridH;y++){
+        for(let x=0;x<gridW;x++){
+            if(machines[y][x] !== 'fissioner') continue;
+            const a = atomAtIncludingHeld(x,y);
+            if(!a || a.type.length<2) continue;
+            const t1=a.type[0], t2=a.type.slice(1);
+            a.type=t1;
+            const newAtom={id:atomIdSeq++,type:t2,x:x+1,y:y,held:false,bonds:[]};
+            atoms.push(newAtom);
+        }
+    }
 }
 function rotateHeld(waldo,cw){
     // rotation placeholder: swap bonds order


### PR DESCRIPTION
## Summary
- spawn inputs at fixed locations regardless of waldo position
- halt waldos on SYNC, crash on wall hits, and prevent wrap-around
- apply bonding/fusing/splitting globally across machines rather than at waldo location

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e87be93c832f97e6b034052270f6