### PR TITLE
Fix SpaceChem core mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,9 @@ let atomIdSeq = 1;
 
 const inputA = ['H','O','C','H','H'];
 const inputB = ['C','H','O','O'];
+// fixed spawn locations for inputs (top-left of each IO region)
+const inputAPos = {x:0,y:0};
+const inputBPos = {x:0,y:4};
 let inputIndexA=0, inputIndexB=0;
 const outputsA=[], outputsB=[];
 
@@ -128,7 +131,10 @@ const blue = new Waldo('blue');
 let startRed = null, startBlue = null;
 
 function atomAt(x,y) {
-    return atoms.find(a => !a.held && a.x===x && a.y===y);
+    return atoms.find(a => {
+        if(a.held) return a.holder.x===x && a.holder.y===y;
+        return a.x===x && a.y===y;
+    });
 }
 
 function drawGrid() {
@@ -330,12 +336,20 @@ function execute(waldo){
     handleInstruction(waldo,instr);
     if(arrow) waldo.dir=arrow;
 
-    // move forward
-    const dir=waldo.dir;
-    if(dir==='right') waldo.x=(waldo.x+1)%gridW;
-    if(dir==='left') waldo.x=(waldo.x+gridW-1)%gridW;
-    if(dir==='up') waldo.y=(waldo.y+gridH-1)%gridH;
-    if(dir==='down') waldo.y=(waldo.y+1)%gridH;
+    // if waiting due to sync, stay put
+    if(waldo.waiting) return;
+
+    // move forward, crash if leaving grid
+    let nx=waldo.x, ny=waldo.y;
+    if(waldo.dir==='right') nx=waldo.x+1;
+    if(waldo.dir==='left') nx=waldo.x-1;
+    if(waldo.dir==='up') ny=waldo.y-1;
+    if(waldo.dir==='down') ny=waldo.y+1;
+    if(nx<0 || nx>=gridW || ny<0 || ny>=gridH){
+        clearInterval(timer); running=false; alert('Waldo crashed into wall'); return;
+    }
+    waldo.x=nx; waldo.y=ny;
+    if(waldo.holding){ waldo.holding.x=waldo.x; waldo.holding.y=waldo.y; }
 }
 
 function handleInstruction(waldo,instr){
@@ -362,29 +376,30 @@ function handleInstruction(waldo,instr){
                 if(a){ waldo.holding=a; a.held=true; a.holder=waldo; }
             }
             break;
-        case 'bond+': doBond(waldo,true); break;
-        case 'bond-': doBond(waldo,false); break;
+        case 'bond+': doBond(true); break;
+        case 'bond-': doBond(false); break;
         case 'sync': waldo.waiting=true; break;
-        case 'inA': spawnInput('A',waldo); break;
-        case 'inB': spawnInput('B',waldo); break;
+        case 'inA': spawnInput('A'); break;
+        case 'inB': spawnInput('B'); break;
         case 'outA': outputAtom('A',waldo); break;
         case 'outB': outputAtom('B',waldo); break;
         case 'swap': doSwap(); break;
-        case 'fuse': fuseAtoms(waldo); break;
-        case 'split': splitAtom(waldo); break;
+        case 'fuse': fuseAtoms(); break;
+        case 'split': splitAtom(); break;
         case 'rotate_cw': rotateHeld(waldo,true); break;
         case 'rotate_ccw': rotateHeld(waldo,false); break;
         // sense, sensors: left as extension; stub
     }
 }
 
-function spawnInput(ch, waldo){
+function spawnInput(ch){
     const list = ch==='A'?inputA:inputB;
     const idx = ch==='A'?inputIndexA:inputIndexB;
     if(idx>=list.length) return;
     const type=list[idx];
     if(ch==='A') inputIndexA++; else inputIndexB++;
-    const a={id:atomIdSeq++,type,x:waldo.x,y:waldo.y,held:false,bonds:[]};
+    const pos = ch==='A'?inputAPos:inputBPos;
+    const a={id:atomIdSeq++,type,x:pos.x,y:pos.y,held:false,bonds:[]};
     atoms.push(a);
 }
 
@@ -396,22 +411,28 @@ function outputAtom(ch, waldo){
     waldo.holding=null;
 }
 
-function doBond(waldo,make){
-    const a = atomAt(waldo.x,waldo.y) || waldo.holding;
-    if(!a) return;
-    const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
-    for(const [dx,dy] of dirs){
-        const nx=waldo.x+dx, ny=waldo.y+dy;
-        if(nx<0||nx>=gridW||ny<0||ny>=gridH) continue;
-        if(machines[ny][nx] && machines[ny][nx].startsWith('bonder')){
-            const b = atomAt(nx,ny) || (waldo.holding && waldo.holding.x===nx&&waldo.holding.y===ny?waldo.holding:null);
-            if(!b || b===a) continue;
-            if(make){
-                if(!a.bonds.includes(b)) a.bonds.push(b);
-                if(!b.bonds.includes(a)) b.bonds.push(a);
-            }else{
-                a.bonds=a.bonds.filter(x=>x!==b);
-                b.bonds=b.bonds.filter(x=>x!==a);
+function doBond(make){
+    const dirs=[[1,0],[0,1]]; // check right and down to avoid duplicates
+    for(let y=0;y<gridH;y++){
+        for(let x=0;x<gridW;x++){
+            const m=machines[y][x];
+            const active=(m==='bonder') || (make && m==='bonder+') || (!make && m==='bonder-');
+            if(!active) continue;
+            const a=atomAt(x,y); if(!a) continue;
+            for(const [dx,dy] of dirs){
+                const nx=x+dx, ny=y+dy;
+                if(nx>=gridW || ny>=gridH) continue;
+                const m2=machines[ny][nx];
+                const active2=(m2==='bonder') || (make && m2==='bonder+') || (!make && m2==='bonder-');
+                if(!active2) continue;
+                const b=atomAt(nx,ny); if(!b) continue;
+                if(make){
+                    if(!a.bonds.includes(b)) a.bonds.push(b);
+                    if(!b.bonds.includes(a)) b.bonds.push(a);
+                }else{
+                    a.bonds=a.bonds.filter(t=>t!==b);
+                    b.bonds=b.bonds.filter(t=>t!==a);
+                }
             }
         }
     }
@@ -434,25 +455,32 @@ function doSwap(){
 }
 
 // simple placeholders for fuse/split/rotate to keep demo functional
-function fuseAtoms(waldo){
-    const a = atomAt(waldo.x,waldo.y);
-    const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
-    for(const [dx,dy] of dirs){
-        const b=atomAt(waldo.x+dx, waldo.y+dy);
-        if(a && b){
-            b.type=a.type+b.type;
-            atoms=atoms.filter(x=>x!==a);
-            break;
+function fuseAtoms(){
+    for(let y=0;y<gridH;y++){
+        for(let x=0;x<gridW-1;x++){
+            if(machines[y][x]==='fuser' && machines[y][x+1]==='fuser'){
+                const a=atomAt(x,y), b=atomAt(x+1,y);
+                if(a && b){
+                    b.type=a.type+b.type;
+                    atoms=atoms.filter(t=>t!==a);
+                }
+            }
         }
     }
 }
-function splitAtom(waldo){
-    const a = atomAt(waldo.x,waldo.y);
-    if(!a || a.type.length<2) return;
-    const t1=a.type[0], t2=a.type.slice(1);
-    a.type=t1;
-    const newAtom={id:atomIdSeq++,type:t2,x:waldo.x,y:waldo.y,held:false,bonds:[]};
-    atoms.push(newAtom);
+function splitAtom(){
+    for(let y=0;y<gridH;y++){
+        for(let x=0;x<gridW-1;x++){
+            if(machines[y][x]==='fissioner' && machines[y][x+1]==='fissioner'){
+                const a=atomAt(x,y);
+                if(!a || a.type.length<2) continue;
+                const t1=a.type[0], t2=a.type.slice(1);
+                a.type=t1;
+                const newAtom={id:atomIdSeq++,type:t2,x:x+1,y:y,held:false,bonds:[]};
+                atoms.push(newAtom);
+            }
+        }
+    }
 }
 function rotateHeld(waldo,cw){
     // rotation placeholder: swap bonds order


### PR DESCRIPTION
## Summary
- handle atoms correctly when grabbed, dropped, or bonded
- execute global BOND, FUSE and SPLIT operations and fixed input spawn points
- prevent waldos from moving during sync and crash on grid edges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896e87be93c832f97e6b034052270f6